### PR TITLE
멤버 bulk api error 발생 시 alert 메세지 수정

### DIFF
--- a/src/features/member-info/components/MemberInfo.tsx
+++ b/src/features/member-info/components/MemberInfo.tsx
@@ -18,6 +18,7 @@ import { InfoActionDialog } from '@/features/member-info/components/InfoActionDi
 import { InfoDeleteDialog } from '@/features/member-info/components/InfoDeleteDialog';
 import { type MemberInfo, ResponseData } from '@/features/member-info/types/member-info';
 import { bulkAddInfo } from '@/features/member-info/apis/addBulkInfo';
+import { AxiosError } from 'axios';
 
 export function MemberInfo() {
   const queryClient = useQueryClient();
@@ -48,9 +49,15 @@ export function MemberInfo() {
       clearUploadedFiles();
       alert('성공적으로 추가되었습니다!');
     },
-    onError: (err) => {
-      
-      alert(`멤버 추가에 실패했습니다: ${err.message}`);
+    onError: (err: unknown) => {
+      if (err instanceof AxiosError) {
+        const apiMessage = err.response?.data?.message;
+        alert(apiMessage ?? '멤버 추가에 실패했습니다.');
+      } else if (err instanceof Error) {
+        alert(err.message);
+      } else {
+        alert('알 수 없는 오류가 발생했습니다.');
+      }
     },
   });
 

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -18,6 +18,7 @@ export const handlers = [
 
     return HttpResponse.json({
       message: 'SUCCESS',
+      errorCode: null,
       data: [
         {
           attendanceId: 1,
@@ -44,6 +45,7 @@ export const handlers = [
 
     return HttpResponse.json({
       message: 'SUCCESS',
+      errorCode: null,
       data: {
         emailTasks: [
           {
@@ -85,6 +87,7 @@ export const handlers = [
 
     return HttpResponse.json({
       message: 'SUCCESS',
+      errorCode: null,
       data: {
         subject: `테스트메일입니다 (ID: ${id} Mocked)`,
         content:
@@ -103,6 +106,7 @@ export const handlers = [
     console.log('MSW: Fetched all members');
     return HttpResponse.json({
       message: 'SUCCESS',
+      errorCode: null,
       data: mockMembers,
       success: true,
     });
@@ -116,6 +120,7 @@ export const handlers = [
 
     return HttpResponse.json({
       message: 'SUCCESS',
+      errorCode: null,
       data: newMemberInfo,
       success: true,
     });
@@ -123,6 +128,16 @@ export const handlers = [
 
   http.post(`${BASE_URL}/members/bulk`, async ({ request }) => {
     const newMemberInfos = (await request.json()) as MemberFormData[];
+
+    const hasDuplicate = newMemberInfos.some(newInfo =>
+      mockMembers.some(existing => existing.studentId === newInfo.studentId)
+    );
+    if (hasDuplicate) {
+      return HttpResponse.json(
+        { message: '이미 존재하는 학번입니다.', errorCode: 'DUPLICATE_STUDENT_ID', success: false },
+        { status: 400 }
+      );
+    }
 
     console.log('MSW: Bulk members added', newMemberInfos);
 
@@ -133,6 +148,7 @@ export const handlers = [
 
     return HttpResponse.json({
       message: 'SUCCESS',
+      errorCode: null,
       data: newMemberInfos,
       success: true,
     });
@@ -152,6 +168,7 @@ export const handlers = [
       console.log('MSW: Member updated', mockMembers[memberIndex]);
       return HttpResponse.json({
         message: 'SUCCESS',
+        errorCode: null,
         data: mockMembers[memberIndex],
         success: true,
       });
@@ -168,7 +185,7 @@ export const handlers = [
 
       if (memberIndex === -1) {
         return HttpResponse.json(
-          { message: 'Member not found' },
+          { message: 'Member not found', errorCode: 'MEMBER_NOT_FOUND', success: false },
           { status: 404 },
         );
       }
@@ -178,6 +195,7 @@ export const handlers = [
       console.log('MSW: Member deleted', deletedMember);
       return HttpResponse.json({
         message: 'SUCCESS',
+        errorCode: null,
         success: true,
       });
     },


### PR DESCRIPTION
### 📎 Title

- closed #24 

### 📃 Changes

1. bulk api error 발생 시, 서버의 `response.data.message`가 alert에 출력되도록 수정
2. local test를 위해 mock api handler에 error case 추가

### 🫨 Considerations

### 📌 Important

### 🎇 Screenshots

<img width="584" height="296" alt="image" src="https://github.com/user-attachments/assets/030cfcd6-c852-4b65-8a79-2a4c37a460ea" />


### 💫 ETC
